### PR TITLE
Setup Github Actions.

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,51 @@
+name: check
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test-cpython:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10"]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install nox
+    - name: Test with pytest
+      run: |
+        nox -s tests_venv_current
+
+  test-conda:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: s-weigand/setup-conda@v1
+      - run: conda --version
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install nox flake8
+      - name: Lint with flake8
+        run: |
+          # Run line only once
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          # flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Test with pytest
+        run: |
+          nox -s tests_multiple_conda

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,102 @@
+name: Build and Upload Python Package
+
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  build_sdist:
+    name: Build sdist
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+
+      - name: Install nox
+        run: python -m pip install nox
+      - name: Build sdist
+        run: nox -s build_sdist
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: |
+            dist/*.tar.gz
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-20.04, macOS-10.15 ]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.3.1
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir dist
+        env:
+          CIBW_BUILD: cp39-* cp310-* *-manylinux_x86_64 *-macosx_x86_64
+      - uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: |
+            dist/*.whl
+  publish:
+    name: Publish
+    needs: [ build_wheels, build_sdist ]
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: dist
+
+      - name: Upload wheels to Github release
+        uses: actions/github-script@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs').promises;
+            const { repo: { owner, repo }, sha } = context;
+            
+            // GITHUB_REF would be refs/tags/<tag_name>
+            const tag = process.env.GITHUB_REF.split("/").pop();
+
+            console.log('environment', process.versions);
+            console.log({ owner, repo, sha });
+
+            const release = await github.repos.getReleaseByTag({ owner, repo, tag });
+
+            console.log('get release', { release });
+
+            for (let file of await fs.readdir('dist')) {
+              console.log('uploading', file);
+              await github.repos.uploadReleaseAsset({
+                owner, repo,
+                release_id: release.data.id,
+                name: file,
+                data: await fs.readFile(`./dist/${file}`)
+              });
+            }
+
+      - name: Publish package to PyPI
+        # Upload to PyPI for a stable release
+        if: ${{ github.event.release.prerelease == false }}
+        env:
+          IS_DEV: ${{ github.repository_owner != 'alibaba' }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          repository_url: ${{ env.IS_DEV && 'https://test.pypi.org/legacy/' || '' }}
+          skip_existing: ${{ env.IS_DEV }}
+          verbose: ${{ env.IS_DEV }}


### PR DESCRIPTION
Setup Github Actions for CI and publishing release:
- Test: Run tests with (basic and conda) cpython with nox on push and pull request;
- Release: Build wheels (manylinux and macos x64);
- Release: Upload wheels to the release that trigger this build;
- Release: Publish to PyPI if this is the main repo (otherwise, to TestPyPI).
